### PR TITLE
Use image#composite

### DIFF
--- a/app/controllers/concerns/histogramr.rb
+++ b/app/controllers/concerns/histogramr.rb
@@ -1,4 +1,5 @@
 module Histogramr
+  # TODO: Should this be put into Histogram class insted?
   extend ActiveSupport::Concern
 
   def to_histogram(img)
@@ -25,35 +26,25 @@ module Histogramr
     histogram.sort_by { |pos, v| v }.reverse
   end
 
+  # Return a Picture with a Histogram that matches the given base grid image's Histogram
+  # Picture is randomly selected from all matching pictures
+  # Error on failure to find image
+  def find_picture_by_hist(base_hist, comp_pics, cache)
+    index = find_index_by_hist(base_hist, comp_pics)
 
-  # Return image corresponding to histogram that matches base img histogram
-  # Error on failure
-  # Image randomly selected from matching images
-  def find_img_by_hist(comp_pics, cache, base_hist)
-    index = find_index_by_hist(comp_pics, base_hist)
-
-    # Raise an error if found no match
-    if index.nil?
-      raise 'Could not find sufficient matching composition images.'
-    elsif cache[index].nil?
-      file = comp_pics[index].image
-      puts 'not cached'
-      img = Image.read(file).first
-      cache[index] = img
+    if cache[index].nil?
+      cache[index] = comp_pics[index]
     else
-      puts 'cached'
       cache[index]
     end
   end
 
-  # Return index corresponding to histogram that matches base img histogram on success
-  # Return nil on failure
-  # Index randomly selected from matching indexes
-  def find_index_by_hist(comp_pics, base_hist)
+  # Return an index for a Histogram that matches the given base grid image's Histogram
+  # Index randomly selected from all matching indexes
+  # Error on failure to find image
+  def find_index_by_hist(base_hist, comp_pics)
     matches = []
     comp_pics.each_with_index do |comp_pic, i|
-      # First [0] accesses highest occuring color
-      # Second [0] accesses reduced color bucket number
       # Determines if they share the same dominant color bucket
       comp_hist = comp_pic.histogram
       if base_hist.dominant_hue == comp_hist.dominant_hue
@@ -61,7 +52,11 @@ module Histogramr
       end
     end
 
-    matches.sample
+    if matches.empty?
+      raise 'Could not find sufficient matching composition images.'
+    else
+      matches.sample
+    end
   end
 
 end

--- a/app/controllers/mosaics_controller.rb
+++ b/app/controllers/mosaics_controller.rb
@@ -34,51 +34,70 @@ class MosaicsController < ApplicationController
 
   def create
     @mosaic = Mosaic.new
-    @user    = current_user
-    #base_img = Image.read(@user.base_pictures[(@user.base_pictures.size - 1)].image).first
-    # At this point we have a histogram version of each of our composition images
-    # Now we need to analyze our base image, breaking it up into a grid
+    @user   = current_user
 
-    # Each grid piece will be anlayzed to determine main color content
-    # Using the list of histograms, we can find the best fitting pictures for each square
-
-    # Grid is an Array of Arrays where outer/inner arrays represent X/Y respectively
-    # Array[0][0] represents upper left corner
-    # For now starting out will be 8 coulmns with 10 rows
-    rows    = 80  
-    columns = 60
-    id = params[:user][:base_picture_ids]
-    @picture = Picture.find(id)
+    # Retrieve image that will be used as basis for mosaic
+    base_id  = params[:user][:base_picture_ids]
+    @picture = Picture.find(base_id)
     base_img = Image.read(@picture.image).first
+    comp_ids = params[:user][:composition_picture_ids]
+    # TODO: Fix this hack work around for "" being sent along with ids
+    # Talks about issue but doesn't fix for me: http://stackoverflow.com/questions/14054164/rails-simple-form-getting-an-empty-string-from-checkbox-collection
+    comp_ids.delete_if { |comp_id| comp_id.empty? }
+    comp_pics = Array.new
+    comp_ids.each do |comp_id|
+      @picture = Picture.find(comp_id)
+      comp_pics << @picture
+    end
+
+    # Divide this base image into a grid and determine the dominant color of each cell
+    # Determine ratio of mosaic image based on aspect of base image
+    mosaic_rows    = 60
+    mosaic_columns = 60
+    if base_img.columns > base_img.rows
+      mosaic_columns *= (base_img.columns / base_img.rows)
+    else
+      mosaic_rows *= (base_img.rows / base_img.columns)
+    end
     
-    # break base_img into grid and set up mosiac img
-    grid_img_width  = base_img.columns / columns
-    grid_img_height = base_img.rows / rows
-    grid_imgs = ImageList.new
-    page  = Magick::Rectangle.new(0,0,0,0)
+    # Determine height/width of the individual grid cells 
+    base_grid_cell_width  = base_img.columns / mosaic_columns
+    base_grid_cell_height = base_img.rows / mosaic_rows
+    # Create list of composition images that comprise the mosaic and their page position
+    mosaic_imgs = ImageList.new
+    page = Magick::Rectangle.new(0,0,0,0)
+    # Create cache for initial lookup and acache for the scaled composition images
     cache = Hash.new
+    # Scale is somewhat arbitrary right now, but it determines size of final mosaic
+    scale = 1
 
-    columns.times do |c|
-      rows.times do |r|
-        # X and Y grid offset
-        page.x = c * grid_img_width
-        page.y = r * grid_img_height
+    # iterate through the grid that will represent the mosaic
+    mosaic_columns.times do |c|
+      mosaic_rows.times do |r|
+        # X and Y current base_img offsets
+        current_grid_x = c * base_grid_cell_width
+        current_grid_y = r * base_grid_cell_height
 
-        # crop to grid cell image and create corresponding histogram
-        cropped_img  = base_img.crop(page.x, page.y, grid_img_width, grid_img_height, true)
+        # Crop to grid cell image and create corresponding histogram
+        # Crop: starting x pixel coord, starting y pixel coord, x pixel length, y pixel length, discard non-cropped
+        cropped_img  = base_img.crop(current_grid_x, current_grid_y, 
+                                      base_grid_cell_width, base_grid_cell_height, true)
         cropped_hist = to_histogram(cropped_img)
-        # find composition image with histgram matching this grid cell image's histogram
-        img = find_img_by_hist(@user.composition_pictures, cache, cropped_hist)
-        # resize image, insert and set page offsets
-        scale = 5
-        grid_imgs << img.scale((grid_img_width * scale), (grid_img_height * scale))
-        page.x *= scale
-        page.y *= scale
-        grid_imgs.page = page
+
+        # Find composition image with matching histogram to base image's current cropped histogram
+        @picture = find_picture_by_hist(cropped_hist, comp_pics, cache)
+        # TODO: Cache scaled images as well
+        mosaic_imgs.read(@picture.image)
+        mosaic_imgs.last.scale!((base_grid_cell_width * scale), (base_grid_cell_height * scale))
+
+        # Insert and set offsets/page
+        page.x = current_grid_x * scale
+        page.y = current_grid_y * scale
+        mosaic_imgs.page = page
       end
     end 
 
-    mosaic = grid_imgs.mosaic
+    mosaic = mosaic_imgs.mosaic
     upload_mosaic(mosaic)
 
     # FIX:: NOT GOOD PRACTICE TO PASS WRONG ID

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -73,10 +73,12 @@ class UsersController < ApplicationController
 
   def delete_pictures
     @user = current_user
+    # TODO: Fix this hack work around for "" being sent along with ids
+    # http://stackoverflow.com/questions/14054164/rails-simple-form-getting-an-empty-string-from-checkbox-collection
+    dirty_ids = params[:user][:composition_picture_ids].concat(params[:user][:base_picture_ids]).concat(params[:user][:mosaic_ids])
+    ids   = dirty_ids.delete_if { |id| id.empty? }
 
-    destroy_all_by_ids(params[:user][:composition_picture_ids])
-    destroy_all_by_ids(params[:user][:base_picture_ids])
-    destroy_all_by_ids(params[:user][:mosaic_ids])
+    destroy_all_by_ids(ids)
 
     flash[:notice] = 'Successfully deleted pictures.'
     render 'show'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,27 @@
 module ApplicationHelper
+
+  def picture_lg(picture)
+    picture_size(picture, 400)
+  end
+
+  def picture_sm(picture)
+    picture_size(picture, 80)
+  end
+
+  def picture_size(picture, base_dimension)
+    puts 'determining size....'
+    binding.pry
+    image   = Image.read(picture.image).first
+    binding.pry
+    columns = image.columns
+    rows    = image.rows
+    x = base_dimension
+    y = base_dimension
+    if columns > rows
+      x *= (columns / rows)
+    else
+      y *= (rows / columns)
+    end
+    "#{x}x#{y}"
+  end
 end

--- a/app/views/modals/_delete.html.erb
+++ b/app/views/modals/_delete.html.erb
@@ -33,9 +33,9 @@
           <div id='hidden_div'>
             <!-- Create lists of check boxes and radio buttons representing composition and base pictures respectively. These are controlled by clicks on images. 
                - Check box/radio button IDs: user_[composition/base]_picture_ids_[id] -->
-            <%= f.association :composition_pictures, collection: @user.composition_pictures,include_hidden: false, include_blank: false, class: 'image-checkbox', as: :check_boxes %>
-            <%= f.association :base_pictures, collection: @user.base_pictures, include_hidden: false, include_blank: false, class: 'image-checkbox', as: :check_boxes %>
-            <%= f.association :mosaics, collection: @user.mosaics, include_hidden: false, include_blank: false, class: 'image-checkbox', as: :check_boxes %>
+            <%= f.association :composition_pictures, collection: @user.composition_pictures, class: 'image-checkbox', as: :check_boxes, :checked => [] %>
+            <%= f.association :base_pictures, collection: @user.base_pictures, include_hidden: false, include_blank: false, class: 'image-checkbox', as: :check_boxes, :checked => [] %>
+            <%= f.association :mosaics, collection: @user.mosaics, class: 'image-checkbox', as: :check_boxes, :checked => [] %>
           </div>
 
         </div>

--- a/app/views/modals/_delete.html.erb
+++ b/app/views/modals/_delete.html.erb
@@ -33,9 +33,9 @@
           <div id='hidden_div'>
             <!-- Create lists of check boxes and radio buttons representing composition and base pictures respectively. These are controlled by clicks on images. 
                - Check box/radio button IDs: user_[composition/base]_picture_ids_[id] -->
-            <%= f.association :composition_pictures, collection: @user.composition_pictures,include_hidden: false, class: 'image-checkbox', as: :check_boxes %>
-            <%= f.association :base_pictures, collection: @user.base_pictures, include_hidden: false, class: 'image-checkbox', as: :check_boxes %>
-            <%= f.association :mosaics, collection: @user.mosaics, include_hidden: false, class: 'image-checkbox', as: :check_boxes %>
+            <%= f.association :composition_pictures, collection: @user.composition_pictures,include_hidden: false, include_blank: false, class: 'image-checkbox', as: :check_boxes %>
+            <%= f.association :base_pictures, collection: @user.base_pictures, include_hidden: false, include_blank: false, class: 'image-checkbox', as: :check_boxes %>
+            <%= f.association :mosaics, collection: @user.mosaics, include_hidden: false, include_blank: false, class: 'image-checkbox', as: :check_boxes %>
           </div>
 
         </div>

--- a/app/views/modals/_select.html.erb
+++ b/app/views/modals/_select.html.erb
@@ -28,8 +28,8 @@
           <div id='hidden_div'>
             <!-- Create lists of check boxes and radio buttons representing composition and base pictures respectively. These are controlled by clicks on images. 
                - Check box/radio button IDs: user_[composition/base]_picture_ids_[id] -->
-            <%= f.association :composition_pictures, collection: @user.composition_pictures,include_hidden: false, class: 'image-checkbox', as: :check_boxes %>
-            <%= f.association :base_pictures, collection: @user.base_pictures, include_hidden: false, class: 'image-radiobutton', as: :radio_buttons %>
+            <%= f.association :composition_pictures, collection: @user.composition_pictures, as: :check_boxes, include_hidden: false, class: 'image-checkbox' } %>
+            <%= f.association :base_pictures, collection: @user.base_pictures, class: 'image-radiobutton', as: :radio_buttons %>
           </div>
 
         </div>

--- a/app/views/modals/_select.html.erb
+++ b/app/views/modals/_select.html.erb
@@ -28,7 +28,7 @@
           <div id='hidden_div'>
             <!-- Create lists of check boxes and radio buttons representing composition and base pictures respectively. These are controlled by clicks on images. 
                - Check box/radio button IDs: user_[composition/base]_picture_ids_[id] -->
-            <%= f.association :composition_pictures, collection: @user.composition_pictures, as: :check_boxes, include_hidden: false, class: 'image-checkbox' } %>
+            <%= f.association :composition_pictures, collection: @user.composition_pictures, as: :check_boxes, include_hidden: false, class: 'image-checkbox' %>
             <%= f.association :base_pictures, collection: @user.base_pictures, class: 'image-radiobutton', as: :radio_buttons %>
           </div>
 

--- a/app/views/mosaics/show.html.erb
+++ b/app/views/mosaics/show.html.erb
@@ -1,7 +1,7 @@
 <h2> Show dis shit </h2>
 
 <!-- TODO: Figure out better sizing scheme. This will just distort -->
-<%= image_tag(@user.mosaics.last.name, size: '560x350',) %>
+<%= image_tag(@user.mosaics.last.name, size: picture_lg(@user.mosaics.last)) %>
 
 </br></br>
 


### PR DESCRIPTION
- Refactor out bugs including one that deleted every picture when attempting to delete one picture and one that sent a blank result causing a crash.
- Create mosaic from an array of ImageMagick Images (instead of an ImageMagick ImageList) and compositing them instead of using the built in 'mosaic' method.
- Create and display mosaics taking their original aspect ratio into consideration instead of forcing as box
- Simplify a good deal of logic in the Histogramr matching methods and move around error structure
- Correctly retrieve mosaic composition images from the form instead of using all images to create mosaic
- General refactor of most names in the mosaic creation method
- Add view helper method to dynamically size images in tiers (small, medium, large) based on their aspect ratio 
- Deselect all images when deleting an image by default
